### PR TITLE
Engine type codes starting with C not allowed.

### DIFF
--- a/src/main/java/com/example/EngineService/Domain/EngineType.java
+++ b/src/main/java/com/example/EngineService/Domain/EngineType.java
@@ -16,6 +16,9 @@ public class EngineType {
         if(code == null || code.trim().isEmpty())
             throw new IllegalArgumentException("Engine Type code was null or empty or a set of blank spaces. Please provide valid code.");
 
+        if(code.startsWith("C"))
+            throw new IllegalArgumentException("Engine type codes starting with C are considered test engine types and are not allowed.");
+
         this.code = code;
         this.description = String.format("Engine type with code %s", code);
         this.creationDateTime = Instant.now();

--- a/src/test/java/com/example/EngineService/Domain/EngineTypeTest.java
+++ b/src/test/java/com/example/EngineService/Domain/EngineTypeTest.java
@@ -40,11 +40,21 @@ class EngineTypeTest {
                 .withMessageEndingWith("Please provide valid code.");
     }
 
+   @Test
+    void constructor_shouldThrowIllegalArgumentException_whenProvidingEngineTypeCodeStartingWithC(){
+        // Arrange
+        String invalidEngineTypeCode = "C-This-is-a-test";
+
+        // Act & Assert
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> { new EngineType(invalidEngineTypeCode);})
+                .withMessage("Engine type codes starting with C are considered test engine types and are not allowed.");
+    }
+
     @Test
     void setDescription_shouldModifyEngineTypeDescription_whenProvidingValidValue() {
         // Arrange
         String originalCode = "ABC-123";
-        String descriptionPattern = "Engine type with code %s";
         EngineType engineType = new EngineType(originalCode);
         String newDescription = "AA_BB_CC";
 


### PR DESCRIPTION
This PR introduces a new business rule that prevents create engine types with `Code` starting with `C` as they are considered test engine types and should not be used.